### PR TITLE
Update parent pom, remove org, and update JTA depedency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
       <groupId>org.eclipse.ee4j</groupId>
       <artifactId>project</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.4</version>
     </parent>
 
     <groupId>jakarta.resource</groupId>
@@ -58,10 +58,6 @@
         </contributor>
     </contributors>
 
-    <organization>
-        <name>Oracle Corporation</name>
-        <url>http://www.oracle.com/</url>
-    </organization>
     <licenses>
         <license>
             <name>EPL 2.0</name>
@@ -151,7 +147,7 @@
                         <Bundle-Description>
                             Java(TM) EE Connector Architecture ${spec.version} API Design Specification
                         </Bundle-Description>
-                        <Specification-Vendor>Oracle Corporation</Specification-Vendor>
+                        <Specification-Vendor>Eclipse Project for JCA</Specification-Vendor>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                         <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
                         <Import-Package>javax.transaction;version="[1.3,2.0)",*</Import-Package>
@@ -317,9 +313,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
-            <version>1.3</version>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>1.3.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Update to the new version of the EE4J parent pom, uptake the Jakarta version of JTA, and remove/update the Oracle references in the pom.

Signed-off-by: Alex Motley <alexmotley82@gmail.com>