### PR TITLE
Update spec-version-maven-plugin version (EE4J_8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
-                <version>1.5</version>
+                <version>2.0</version>
                 <configuration>
                     <specMode>jakarta</specMode>
                     <spec>


### PR DESCRIPTION
Update the spec-version-maven-plugin to the 2.0 version. This fixes the bundle symbolic name issue in #26.

Signed-off-by: Alex Motley <alexmotley82@gmail.com>