### PR TITLE
Update to 1.3.2 version of JTA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The version of JTA was updated in the release tracker (Eclipse_GlassFish_5.1_Components_Release_Tracker), so we should update the version jca-api depends on.

Signed-off-by: Alex Motley <alexmotley82@gmail.com>