### PR TITLE
Increment POM versions as 

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.resource</groupId>
     <artifactId>jakarta.resource-api</artifactId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
     
     <properties>
         <extension.name>javax.resource</extension.name>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.eclipse.ee4j.jca-api</groupId>
     <artifactId>jca-api-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
     <name>${extension.name} API</name>
     <description>Jakarta Connectors</description>
     <url>https://github.com/eclipse-ee4j/jca-api</url>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta.resource</groupId>
     <artifactId>connectors-spec</artifactId>
     <packaging>pom</packaging>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
     <name>Jakarta Connectors Specification</name>
 
     <properties>


### PR DESCRIPTION
1.7.3 was released to maven central in January 2019 so we need to increment the poms. Only noticed after going through the whole release to staging

https://search.maven.org/artifact/jakarta.resource/jakarta.resource-api/1.7.3/jar

Signed-off-by: smillidge <steve.millidge@payara.fish>