### PR TITLE
port issue #73 to 2.0.0 branch

### DIFF
--- a/spec/src/main/asciidoc/Connectors.adoc
+++ b/spec/src/main/asciidoc/Connectors.adoc
@@ -19379,6 +19379,11 @@ a Java EE application _EAR_ (also referred to as an “embedded RAR”) is
 deployed, the resource adapter must be made available only to the Java
 EE application with which it is packaged.
 
+A resource adapter must not implement or
+require a mixture of Jakarta and Java EE packages. If a resource adapter
+provider wishes to implement both specifications, it must do so by
+providing multiple _RAR_ files.
+
 === 
 
 image:conn-153.png[image]

--- a/spec/src/main/asciidoc/Connectors.txt
+++ b/spec/src/main/asciidoc/Connectors.txt
@@ -21617,6 +21617,11 @@ a Java EE application _EAR_ (also referred to as an “embedded RAR”) is
 deployed, the resource adapter must be made available only to the Java
 EE application with which it is packaged.
 
+[#50540561_pgfId-999753]##A resource adapter must not implement or
+require a mixture of Jakarta and Java EE packages. If a resource adapter
+provider wishes to implement both specifications, it must do so by
+providing multiple _RAR_ files.
+
 ======= [#50540561_pgfId-999754]##
 
 image:conn-153.gif[image]


### PR DESCRIPTION
It looks like I had pull #77 for issue #73 targeted against the wrong branch.  This pull should get the change into the 2.0.0 branch where it belongs.

@smillidge  you were the original reviewer on pull #77, which I had accidentally targeted for 2.0.0.RELEASE rather than the 2.0.0 branch. Would you mind reviewing this correction to get the same change into 2.0.0 ?  It appears that the text of the spec is now duplicated between an adoc file and a txt file, so I've included the change in both.  Let me know if that wasn't correct.