### PR TITLE
Adjust javax-to-jakarta renames

### DIFF
--- a/api/src/main/java/jakarta/resource/AdministeredObjectDefinition.java
+++ b/api/src/main/java/jakarta/resource/AdministeredObjectDefinition.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *  by a component using the <code>lookup</code> element of the
  *  <code>Resource</code> annotation.
  *
- *  @see javax.annotation.Resource
+ *  @see jakarta.annotation.Resource
  *  @version 1.7
  *  @since 1.7
  */

--- a/api/src/main/java/jakarta/resource/ConnectionFactoryDefinition.java
+++ b/api/src/main/java/jakarta/resource/ConnectionFactoryDefinition.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Repeatable;
  *  Once defined, a resource may be referenced by a component using the
  *  <code>lookup</code> element of the <code>Resource</code> annotation.
  *
- *  @see javax.annotation.Resource
+ *  @see jakarta.annotation.Resource
  *  @version 1.7
  *  @since 1.7
  */

--- a/api/src/main/java/jakarta/resource/Referenceable.java
+++ b/api/src/main/java/jakarta/resource/Referenceable.java
@@ -26,7 +26,7 @@ import javax.naming.Reference;
  *
  *  <p>The implementation class for a connection factory interface is 
  *  required to implement both java.io.Serializable and 
- *  javax.resource.Referenceable interfaces to support JNDI registration.
+ *  jakarta.resource.Referenceable interfaces to support JNDI registration.
  *
  *  @version     0.9
  *  @author      Rahul Sharma

--- a/api/src/main/java/jakarta/resource/cci/ConnectionFactory.java
+++ b/api/src/main/java/jakarta/resource/cci/ConnectionFactory.java
@@ -68,7 +68,7 @@ public interface ConnectionFactory
   Connection getConnection() throws ResourceException;
 
   /** Gets a connection to an EIS instance. A component should use 
-   *  the getConnection variant with javax.resource.cci.ConnectionSpec
+   *  the getConnection variant with jakarta.resource.cci.ConnectionSpec
    *  parameter, if it needs to pass any resource adapter specific 
    *  security information and connection parameters. In the component-
    *  managed sign-on case, an application component passes security 

--- a/api/src/main/java/jakarta/resource/cci/Interaction.java
+++ b/api/src/main/java/jakarta/resource/cci/Interaction.java
@@ -20,7 +20,7 @@ import jakarta.resource.ResourceException;
 import jakarta.resource.NotSupportedException;
 
 
-/** The <code>javax.resource.cci.Interaction</code> enables a component to 
+/** The <code>jakarta.resource.cci.Interaction</code> enables a component to 
  *  execute EIS functions. An Interaction instance supports the following ways 
  *  of interacting with an EIS instance:
  *  <UL>

--- a/api/src/main/java/jakarta/resource/cci/MappedRecord.java
+++ b/api/src/main/java/jakarta/resource/cci/MappedRecord.java
@@ -16,7 +16,7 @@
 
 package jakarta.resource.cci;
 
-/** The interface <code>javax.resource.cci.MappedRecord</code> is 
+/** The interface <code>jakarta.resource.cci.MappedRecord</code> is 
  *  used for key-value map based representation of record elements. 
  *  The MappedRecord interface extends both <code>Record</code> and 
  *  <code>java.util.Map</code>interfaces. 

--- a/api/src/main/java/jakarta/resource/cci/ResourceAdapterMetaData.java
+++ b/api/src/main/java/jakarta/resource/cci/ResourceAdapterMetaData.java
@@ -16,7 +16,7 @@
 
 package jakarta.resource.cci;
 
-/** The interface <code>javax.resource.cci.ResourceAdapterMetaData</code> 
+/** The interface <code>jakarta.resource.cci.ResourceAdapterMetaData</code> 
  *  provides information about capabilities of a resource adapter 
  *  implementation. Note that this interface does not provide information 
  *  about an EIS instance that is connected through the resource adapter.

--- a/api/src/main/java/jakarta/resource/cci/package.html
+++ b/api/src/main/java/jakarta/resource/cci/package.html
@@ -20,7 +20,7 @@
 
 </head>
 <body>
-The javax.resource.cci package contains API specification for the Common
+The jakarta.resource.cci package contains API specification for the Common
 Client Interface (CCI).
 </body>
 </html>

--- a/api/src/main/java/jakarta/resource/package.html
+++ b/api/src/main/java/jakarta/resource/package.html
@@ -20,6 +20,6 @@
 
 </head>
 <body>
-The javax.resource package is the top-level package for the Jakarta&trade; Connectors specification. 
+The jakarta.resource package is the top-level package for the Jakarta&trade; Connectors specification. 
 </body>
 </html>

--- a/api/src/main/java/jakarta/resource/spi/AuthenticationMechanism.java
+++ b/api/src/main/java/jakarta/resource/spi/AuthenticationMechanism.java
@@ -47,7 +47,7 @@ public @interface AuthenticationMechanism {
     public enum CredentialInterface {
         /**
          * Corresponds to 
-         * <code>javax.resource.spi.security.PasswordCredential</code>.
+         * <code>jakarta.resource.spi.security.PasswordCredential</code>.
          * This is the default credential interface
          */
         PasswordCredential, 
@@ -59,7 +59,7 @@ public @interface AuthenticationMechanism {
         
         /**
          * Corresponds to 
-         * <code>javax.resource.spi.security.GenericCredential</code>
+         * <code>jakarta.resource.spi.security.GenericCredential</code>
          */
         GenericCredential 
     }
@@ -85,10 +85,10 @@ public @interface AuthenticationMechanism {
      * supports for the representation of the credentials.
      *
      * Note that BasicPassword mechanism type should support the
-     * <code>javax.resource.spi.security.PasswordCredential</code> interface.
+     * <code>jakarta.resource.spi.security.PasswordCredential</code> interface.
      * The Kerbv5 mechanism type should support the
      * <code>org.ietf.jgss.GSSCredential</code> interface or the deprecated
-     * <code>javax.resource.spi.security.GenericCredential</code> interface.
+     * <code>jakarta.resource.spi.security.GenericCredential</code> interface.
      */
     CredentialInterface credentialInterface() 
     					default CredentialInterface.PasswordCredential;

--- a/api/src/main/java/jakarta/resource/spi/ConnectionDefinition.java
+++ b/api/src/main/java/jakarta/resource/spi/ConnectionDefinition.java
@@ -41,7 +41,7 @@ public @interface ConnectionDefinition {
 
 	/**
 	 * Specifies the ConnectionFactory interface supported by the resource
-	 * adapter. Example: javax.resource.cci.ConnectionFactory or
+	 * adapter. Example: jakarta.resource.cci.ConnectionFactory or
 	 * com.wombat.ConnectionFactory
 	 */
 	Class connectionFactory();
@@ -55,7 +55,7 @@ public @interface ConnectionDefinition {
 
 	/**
 	 * Specifies the Connection interface supported by the resource adapter.
-	 * Example: javax.resource.cci.Connection or com.wombat.Connection
+	 * Example: jakarta.resource.cci.Connection or com.wombat.Connection
 	 */
 	Class connection();
 

--- a/api/src/main/java/jakarta/resource/spi/LocalTransaction.java
+++ b/api/src/main/java/jakarta/resource/spi/LocalTransaction.java
@@ -22,7 +22,7 @@ import jakarta.resource.ResourceException;
  *  are managed internal to an EIS resource manager, and do not require
  *  an external transaction manager.
  * 
- *  <p>A resource adapter implements the javax.resource.spi.LocalTransaction 
+ *  <p>A resource adapter implements the jakarta.resource.spi.LocalTransaction 
  *  interface to provide support for local transactions that are performed
  *  on the underlying resource manager.
  *

--- a/api/src/main/java/jakarta/resource/spi/ManagedConnection.java
+++ b/api/src/main/java/jakarta/resource/spi/ManagedConnection.java
@@ -25,7 +25,7 @@ import jakarta.resource.ResourceException;
  *
  *  <p>A ManagedConnection instance provides access to a pair of 
  *  interfaces: <code>javax.transaction.xa.XAResource</code> and 
- *  <code>javax.resource.spi.LocalTransaction</code>.
+ *  <code>jakarta.resource.spi.LocalTransaction</code>.
  *
  *  <p><code> XAResource</code> interface is used by the transaction 
  *  manager to associate and dissociate a transaction with the underlying 
@@ -62,7 +62,7 @@ public interface ManagedConnection {
    *  @return       generic Object instance representing the connection 
    *                handle. For CCI, the connection handle created by a 
    *                ManagedConnection instance is of the type 
-   *                javax.resource.cci.Connection.
+   *                jakarta.resource.cci.Connection.
    *
    *  @throws  ResourceException     generic exception if operation fails
    *  @throws  ResourceAdapterInternalException
@@ -202,7 +202,7 @@ public interface ManagedConnection {
   public 
   XAResource getXAResource() throws ResourceException;
 
-  /** Returns an <code>javax.resource.spi.LocalTransaction</code> instance. 
+  /** Returns an <code>jakarta.resource.spi.LocalTransaction</code> instance. 
    *  The LocalTransaction interface is used by the container to manage
    *  local transactions for a RM instance.
    *

--- a/api/src/main/java/jakarta/resource/spi/ManagedConnectionFactory.java
+++ b/api/src/main/java/jakarta/resource/spi/ManagedConnectionFactory.java
@@ -45,7 +45,7 @@ public interface ManagedConnectionFactory extends java.io.Serializable {
      *  @param    cxManager    ConnectionManager to be associated with
      *                         created EIS connection factory instance
      *  @return   EIS-specific Connection Factory instance or
-     *            javax.resource.cci.ConnectionFactory instance
+     *            jakarta.resource.cci.ConnectionFactory instance
      *   
      *  @throws   ResourceException     Generic exception
      *  @throws   ResourceAdapterInternalException
@@ -60,7 +60,7 @@ public interface ManagedConnectionFactory extends java.io.Serializable {
      *  by the resource adapter.
      *
      *  @return   EIS-specific Connection Factory instance or
-     *            javax.resource.cci.ConnectionFactory instance
+     *            jakarta.resource.cci.ConnectionFactory instance
      *
      *  @throws   ResourceException     Generic exception
      *  @throws   ResourceAdapterInternalException

--- a/api/src/main/java/jakarta/resource/spi/package.html
+++ b/api/src/main/java/jakarta/resource/spi/package.html
@@ -20,7 +20,7 @@
 
 </head>
 <body>
-The javax.resource.spi package contains APIs for the system
+The jakarta.resource.spi package contains APIs for the system
 contracts defined in the Jakarta Connectors specification.
 </body>
 </html>

--- a/api/src/main/java/jakarta/resource/spi/security/GenericCredential.java
+++ b/api/src/main/java/jakarta/resource/spi/security/GenericCredential.java
@@ -18,7 +18,7 @@ package jakarta.resource.spi.security;
 
 import jakarta.resource.spi.SecurityException;
 
-/** The interface <code>javax.resource.spi.security.GenericCredential</code> 
+/** The interface <code>jakarta.resource.spi.security.GenericCredential</code> 
  *  defines a security mechanism independent interface for accessing 
  *  security credential of a resource principal. 
  *

--- a/api/src/main/java/jakarta/resource/spi/security/package.html
+++ b/api/src/main/java/jakarta/resource/spi/security/package.html
@@ -20,7 +20,7 @@
 
 </head>
 <body>
-The javax.resource.spi.security package contains APIs for the security
+The jakarta.resource.spi.security package contains APIs for the security
 management contract.
 </body>
 </html>

--- a/api/src/main/java/jakarta/resource/spi/work/HintsContext.java
+++ b/api/src/main/java/jakarta/resource/spi/work/HintsContext.java
@@ -37,8 +37,8 @@ public class HintsContext implements WorkContext {
 	 */
 	private static final long serialVersionUID = 7956353628297167255L;
 	
-	public static final String NAME_HINT = "javax.resource.Name";
-	public static final String LONGRUNNING_HINT = "javax.resource.LongRunning";
+	public static final String NAME_HINT = "jakarta.resource.Name";
+	public static final String LONGRUNNING_HINT = "jakarta.resource.LongRunning";
 
 	protected String description = "Hints Context";
 	protected String name = "HintsContext";
@@ -82,7 +82,7 @@ public class HintsContext implements WorkContext {
 	/**
 	 * Set a Hint and a related value. The hintName must be non-Null. Standard
 	 * HintNames are defined in the Jakarta Connectors specification. Use of
-	 * "javax.resource." prefixed hintNames are reserved for use by the
+	 * "jakarta.resource." prefixed hintNames are reserved for use by the
 	 * Jakarta Connectors specification.
 	 * 
 	 */

--- a/spec/src/main/asciidoc/Connectors.adoc
+++ b/spec/src/main/asciidoc/Connectors.adoc
@@ -3822,7 +3822,7 @@ public interface jakarta.resource.spi.ManagedConnection {
 ----
 
 A _Managed_ Connection instance provides
-access to a pair of interfaces: _jakarta.transaction.xa.XAResource_ and
+access to a pair of interfaces: _javax.transaction.xa.XAResource_ and
 _jakarta.resource.spi.LocalTransaction_ .
 
 Depending on the transaction support level of
@@ -3850,7 +3850,7 @@ _LocalTransaction_ interface to manage local transactions.
 
 ==== Interface: XAResource
 
-The _jakarta.transaction.xa.XAResource_
+The _javax.transaction.xa.XAResource_
 interface is a Java mapping of the industry standard _XA_ interface
 based on _X/Open CAE specification_ (see
 <<a9729, X/Open CAE Specification -- Distributed
@@ -3867,7 +3867,7 @@ specifications:
 [source,Java]
 ----
 public interface
-jakarta.transaction.xa.XAResource {
+javax.transaction.xa.XAResource {
 
  public void commit(Xid xid, boolean onePhase) throws XAException;
 
@@ -11654,8 +11654,8 @@ image:conn-127.jpg[image]
 ----
  package jakarta.resource.spi.work;
 
- import jakarta.security.auth.Subject;
- import jakarta.security.auth.callback.CallbackHandler;
+ import javax.security.auth.Subject;
+ import javax.security.auth.callback.CallbackHandler;
 
  public abstract class SecurityContext implements WorkContext {
 
@@ -12500,7 +12500,7 @@ _ConnectionFactory_ must implement the _java.io.Serializable_ interface
 to support JNDI registration. A _ConnectionFactory_ implementation class
 is also required to implement _jakarta.resource.Referenceable_ . Note that
 the _jakarta.resource.Referenceable_ interface extends the
-_jakarta.naming.Referenceable_ interface. Refer to
+_javax.naming.Referenceable_ interface. Refer to
 <<a5258, JNDI Configuration and Lookup>> for more
 details on JNDI based requirements for the _ConnectionFactory_
 implementation.


### PR DESCRIPTION
There are two commits in this PR:

1. Restore javax where javax-to-jakarta was over-corrected
2. Apply the javax-to-jakarta rename where it was still needed
