### PR TITLE
UT to show IPEx not being serializable

### DIFF
--- a/api/src/test/java/jakarta/resource/spi/EchoBean.java
+++ b/api/src/test/java/jakarta/resource/spi/EchoBean.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.resource.spi;
+
+public class EchoBean {
+  private int v;
+
+  public int getEcho() { return 0; }
+
+  public void setEcho(int e) { v = e; }
+}
+

--- a/api/src/test/java/jakarta/resource/spi/InvalidPropertyExceptionTest.java
+++ b/api/src/test/java/jakarta/resource/spi/InvalidPropertyExceptionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.resource.spi;
+
+import java.beans.PropertyDescriptor;
+import java.io.*;
+
+public class InvalidPropertyExceptionTest {
+    public void testSerializability() throws Exception {
+        PropertyDescriptor ipd [] = { new PropertyDescriptor("echo", EchoBean.class) };
+        var ipex = new InvalidPropertyException();
+        ipex.setInvalidPropertyDescriptors(ipd);
+
+        try (var baos = new ByteArrayOutputStream()) {
+            try (var oos = new ObjectOutputStream(baos)) {
+                oos.writeObject(ipex);
+            }
+
+            var bais = new ByteArrayInputStream(baos.toByteArray());
+            try (var ois = new ObjectInputStream(bais)) {
+                var ripex = (InvalidPropertyException)ois.readObject();
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This fails with
```
[INFO] --- surefire:3.2.5:test (default-test) @ jakarta.resource-api ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit.JUnit3Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running jakarta.resource.spi.InvalidPropertyExceptionTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.116 s <<< FAILURE! -- in jakarta.resource.spi.InvalidPropertyExceptionTest
[ERROR] jakarta.resource.spi.InvalidPropertyExceptionTest.jakarta.resource.spi.InvalidPropertyExceptionTest.testSerializability() -- Time elapsed: 0.100 s <<< FAILURE!
java.io.NotSerializableException: java.beans.PropertyDescriptor
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1200)
	at java.base/java.io.ObjectOutputStream.writeArray(ObjectOutputStream.java:1394)
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1190)
	at java.base/java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1585)
	at java.base/java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1542)
	at java.base/java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1451)
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1194)
	at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:358)
	at jakarta.resource@2.1.1-SNAPSHOT/jakarta.resource.spi.InvalidPropertyExceptionTest.testSerializability(InvalidPropertyExceptionTest.java:30)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.maven.surefire.junit.PojoTestSetExecutor.executeTestMethod(PojoTestSetExecutor.java:104)
	at org.apache.maven.surefire.junit.PojoTestSetExecutor.execute(PojoTestSetExecutor.java:63)
	at org.apache.maven.surefire.junit.JUnit3Provider.executeTestSet(JUnit3Provider.java:131)
	at org.apache.maven.surefire.junit.JUnit3Provider.invoke(JUnit3Provider.java:93)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   jakarta.resource.spi.InvalidPropertyExceptionTest#testSerializability NotSerializableException java.beans.PropertyDescriptor
```