### PR TITLE
Clarify requirement for thread-safe access to ConnectionEventListeners

### DIFF
--- a/spec/src/main/asciidoc/Connectors.adoc
+++ b/spec/src/main/asciidoc/Connectors.adoc
@@ -1,7 +1,7 @@
 :sectnums:
 == Jakarta Connectors, Version 2.1
 
-Copyright (c) 2013, 2022 Eclipse Foundation, Oracle and/or its affiliates
+Copyright (c) 2013, 2025 Eclipse Foundation, Oracle and/or its affiliates
 
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 
@@ -2765,11 +2765,10 @@ of listeners.
 
 The _removeConnectionEventListener_ method
 removes a registered _ConnectionEventListener_ instance from a
-_ManagedConnection_ instance. Since an application server may modify the
-list of event listeners at a time when the _ManagedConnection_ may be
-iterating through its list of event listeners, the resource adapter is
-recommended to handle this scenario by synchronizing access to its list
-of event listeners.
+_ManagedConnection_ instance. Because an application server can modify the
+list of event listeners at a time when the _ManagedConnection_ might be
+iterating through its list of event listeners, the resource adapter must
+always ensure thread-safe access to its list of event listeners.
 
 The method _getMetaData_ returns the metadata
 information (represented by the _ManagedConnectionMetaData_ interface)


### PR DESCRIPTION
Fixes #156

Improves language in the spec to clarify that it is a requirement for resource adapters to arrange for thread-safe access to a ManagedConnection's list of registered ConnectionEventListeners.