### PR TITLE
Preparatory work in advance of covering read-only transactions

### DIFF
--- a/spec/src/main/asciidoc/Connectors.adoc
+++ b/spec/src/main/asciidoc/Connectors.adoc
@@ -3505,7 +3505,7 @@ passed as a _Subject_ instance, any _ConnectionRequestInfo instance_ ,
 and its configured set of properties, such as port number, server name,
 to create a new _ManagedConnection_ instance.
 * The _ManagedConnectionFactory_ initializes
-the state of the created _Managed-Connection_ instance and returns it to
+the state of the created _ManagedConnection_ instance and returns it to
 the default _ConnectionManager_ instance.
 * The _ConnectionManager_ instance calls the
 _ManagedConnection.getConnection_ method to get an application-level
@@ -3789,12 +3789,12 @@ image:conn-52.svg[image]
 
 ==== Interface: ManagedConnection
 
-The _jakarta.resource.spi.Managed_ Connection
+The _jakarta.resource.spi.ManagedConnection_
 instance represents a physical connection to an EIS and acts as a
 factory for connection handles.
 
 The following code extract shows the methods
-on _the ManagedConnection_ interface that are defined specifically for
+on the _ManagedConnection_ interface that are defined specifically for
 the transaction management contract:
 
 [source,Java]
@@ -4058,7 +4058,7 @@ involved in a transaction with none or multiple 2PC enabled RMs
 ==== Resource Adapter Requirements
 
 Jakarta Connectors does not require
-that all resource adapters must support Jakarta Transaction
+that all resource adapters must support a Jakarta Transaction
 _XAResource_ based transaction contract.
 
 If a resource adapter decides to support an
@@ -4137,7 +4137,7 @@ method and must be able to report whether it can guarantee its ability
 to commit the transaction branch. If the RM reports that it can, the RM
 must hold and record in a stable way all the resources necessary to
 commit the branch. It must hold all these resources until the TM directs
-it to commit or rollback the branch.
+it to commit or roll back the branch.
 
 * An RM that reports a heuristic completion to
 the TM must not discard its knowledge of the transaction branch. The RM
@@ -4288,8 +4288,8 @@ connection management contract. <<a976, OID: Connection Pool Management with Con
 handles the connection allocation request.
 
 . To handle the connection allocation request,
-the application server gets a _Managed-Connection_ instance either from
-the connection pool or creates a new _Managed-Connection_ instance.
+the application server gets a _ManagedConnection_ instance either from
+the connection pool or creates a new _ManagedConnection_ instance.
 <<a976, OID: Connection Pool Management with Connection Matching>> describes this step.
 
 . The application server registers itself as a

--- a/spec/src/main/asciidoc/Connectors.adoc
+++ b/spec/src/main/asciidoc/Connectors.adoc
@@ -1,7 +1,7 @@
 :sectnums:
 == Jakarta Connectors, Version {specVersion}
 
-Copyright (c) 2013, 2025 Eclipse Foundation, Oracle and/or its affiliates
+Copyright (c) 2013, 2026 Eclipse Foundation, Oracle and/or its affiliates
 
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 
@@ -3648,7 +3648,7 @@ transactions:
 
 * A transaction that is controlled and
 coordinated by a transaction manager external to the resource manager.
-This document refers to such a transaction as Jakarta Transaction or XA transaction.
+This document refers to such a transaction as a Jakarta Transaction or XA transaction.
 * A transaction that is managed internal to a
 resource manager. The coordination of such transactions involves no
 external transaction managers. This document refers to such transactions
@@ -3701,10 +3701,10 @@ EIS resource managers. The transaction manager manages transactions
 across multiple resource managers and supports propagation of the
 transaction context across distributed systems.
 
-The transaction manager supports a Jakarta Transaction
+The transaction manager supports a Jakarta Transactions
 _XAResource_ -based transaction management contract with a resource
 adapter and its underlying resource manager. The ERP system supports
-Jakarta Transaction  by implementing an _XAResource_ interface through its
+Jakarta Transactions by implementing an _XAResource_ interface through its
 resource adapter. The TP system also implements an _XAResource_
 interface. This interface enables the two resource managers to
 participate in transactions that are coordinated by an external
@@ -3727,7 +3727,7 @@ back.
 The transactions are demarcated either by the
 container (called container-managed demarcation) or by a component
 (called component-managed demarcation). In component-managed
-demarcation, an application component can use the Jakarta Transaction
+demarcation, an application component can use the Jakarta Transactions
 _UserTransaction_ interface or a transaction demarcation API specific to
 an EIS (for example, JDBC transaction demarcation using _java.sql.Connection_ ).
 
@@ -3926,7 +3926,7 @@ transactions for a resource manager.
 <<a1285, Interface: LocalTransaction>> has more details on the local transaction management
 contract.
 
-=== Relationship to Jakarta Transaction and JTS
+=== Relationship to Jakarta Transactions and JTS
 
 The {lkTransSpec}
 is a specification of interfaces between a
@@ -3944,12 +3944,12 @@ infrastructure for enterprise middleware. For example, an application
 server vendor can use a JTS implementation as the underlying transaction
 manager.
 
-==== Jakarta Transaction Interfaces
+==== Jakarta Transactions Interfaces
 
 The application server uses the
 _jakarta.transaction.TransactionManager_ and
 _jakarta.transaction.Transaction_ interfaces, specified
-in the Jakarta Transaction specification, for its contract with
+in the Jakarta Transactions specification, for its contract with
 the transaction manager.
 
 The application server uses the
@@ -4010,7 +4010,7 @@ Examples of RM: Oracle and DB2 installations
 that support 2PC in their _XAResource_ implementations.
 
 |Supported based on TM's requirement to be
-Jakarta Transaction/JTS and X/Open compliant, and RM's support for 2PC in the
+Jakarta Transactions/JTS and X/Open compliant, and RM's support for 2PC in the
 _XAResource_ interface.
 
 |TM does one-phase commit (1PC) optimization
@@ -4022,7 +4022,7 @@ Example of RM: DB2 installation that supports
 2PC in its _XAResource_ implementation.
 
 |Supported based on TM's requirement to be
-Jakarta Transaction/JTS and X/Open compliant, and RM's support for the XAResource
+Jakarta Transactions/JTS and X/Open compliant, and RM's support for the XAResource
 interface.
 
 Note: This scenario will also work if TM does
@@ -4058,7 +4058,7 @@ involved in a transaction with none or multiple 2PC enabled RMs
 ==== Resource Adapter Requirements
 
 Jakarta Connectors does not require
-that all resource adapters must support a Jakarta Transaction
+that all resource adapters must support a Jakarta Transactions
 _XAResource_ based transaction contract.
 
 If a resource adapter decides to support an
@@ -4073,10 +4073,10 @@ underlying resource manager for supporting the transaction contract is
 implementation-specific and is out of the scope of Jakarta Connectors.
 
 These requirements assume that a transaction
-manager (TM) supports Jakarta Transaction/XA and JTS requirements.
+manager (TM) supports Jakarta Transactions/XA and JTS requirements.
 
 The following set of requirements are based on
-the Jakarta Transaction and XA specifications and should be read
+the Jakarta Transactions and XA specifications and should be read
 in conjunction with these specifications. These detailed
 requirements are included in this document to clearly specify the
 requirements from the Jakarta Connectors perspective.
@@ -4201,7 +4201,7 @@ not altered by the communication process.
 
 ===== Support for Failure Recovery
 
-* A full Jakarta Transaction compliant _XAResource_
+* A full Jakarta Transactions compliant _XAResource_
 implementation that supports 2PC must maintain the status of all
 transaction branches in which it is involved. After responding
 affirmatively to the TM _prepare_ call, an RM should not erase its
@@ -4225,7 +4225,7 @@ discard its knowledge of all other branches.
 ==== Transaction Manager Requirements
 
 The following section specifies requirements
-of a TM. This section assumes that the TM is compliant with Jakarta Transaction/JTS
+of a TM. This section assumes that the TM is compliant with Jakarta Transactions/JTS
 and X/Open (see {lkXOpenSpec}) specifications.
 
 ===== Interfaces
@@ -4315,7 +4315,7 @@ instance associated with the _ManagedConnection_ instance.
 . The application server enlists the
 _XAResource_ instance with the transaction manager for the current
 transaction context. The application server uses the _Transaction_ .
-_enlistResource_ method (specified in the Jakarta Transaction specification) to enlist
+_enlistResource_ method (specified in the Jakarta Transactions specification) to enlist
 the _XAResource_ instance with the transaction manager. This enlistment
 informs the transaction manager about the resource manager instance
 participating in the transaction.
@@ -4343,7 +4343,7 @@ connection request.
 
 image:conn-55.svg[image]
 
-==== Scenario: Connection Close and Jakarta Transaction Transactional Cleanup
+==== Scenario: Connection Close and Jakarta Transactions Transactional Cleanup
 
 For each _ManagedConnection_ instance in the
 pool, the application server registers a _ConnectionEventListener_
@@ -5381,7 +5381,7 @@ The following are the requirements for an
 application server for the transaction management contract:
 
 * The application server must support a
-transaction manager that manages transactions using the Jakarta Transaction _XAResource_
+transaction manager that manages transactions using the Jakarta Transactions _XAResource_
 -based contract. The requirements for a transaction manager to support
 an _XAResource_ -based contract are specified in
 <<a1233, Transaction Manager Requirements>>.
@@ -10006,7 +10006,7 @@ call in order to send back an acknowledgement to its provider.
 
 Depending on the endpoint preferences, the
 application server brackets the message delivery to an endpoint instance
-with a Jakarta Transaction's transaction.
+with a Jakarta Transactions transaction.
 
 * This ensures that all the work done by the
 endpoint instance is enlisted as part of the transaction.
@@ -10173,7 +10173,7 @@ method call must be aborted by the application server.
 ==== Non-Transacted Delivery
 
 1. The application server does not bracket the
-message delivery to an endpoint instance within a Jakarta Transaction's transaction.
+message delivery to an endpoint instance within a Jakarta Transactions transaction.
 
 2. The resource adapter relies on the successful
 return of the message delivery call on the endpoint instance for
@@ -15695,14 +15695,14 @@ be any one of the following: _NoTransaction_ , _LocalTransaction_ , or
 _XATransaction_ . Note that this support is specified for a resource
 adapter and not for the underlying EIS instance. +
 _NoTransaction_ : The resource adapter does not support either the
-resource manager local or Jakarta Transaction's transactions. It does not implement either
+resource manager local or Jakarta Transactions transactions. It does not implement either
 _XAResource_ or _LocalTransaction_ interfaces. +
 _LocalTransaction_ : The resource adapter supports resource manager
 local transactions by implementing the _LocalTransaction_ interface. The
 local transaction management contract is specified in
 <<a1280, Local Transaction Management Contract>>. +
 _XATransaction_ : The resource adapter supports both resource manager
-local and Jakarta Transaction's transactions by implementing the _LocalTransaction_ and
+local and Jakarta Transactions transactions by implementing the _LocalTransaction_ and
 _XAResource_ interfaces respectively. The requirements for supporting
 the _XAResource_ based contract are specified in
 <<a1169, XAResource-based Transaction Contract>>.
@@ -18013,7 +18013,7 @@ connection has been denied.
 
 * _jakarta.resource.spi.LocalTransactionException_ . A
 _LocalTransaction-Exception_ represents various error conditions related
-to the local transaction management contract. The Jakarta Transaction specification
+to the local transaction management contract. The Jakarta Transactions specification
 specifies the _javax.transaction-.xa.XAException_ class for exceptions
 related to an _XAResource_ -based transaction management contract. The
 _LocalTransactionException_ is used for the local transaction management

--- a/spec/src/main/asciidoc/chapters/references.adoc
+++ b/spec/src/main/asciidoc/chapters/references.adoc
@@ -23,15 +23,14 @@
 :lkJavaSE: link:https://docs.oracle.com/en/java/javase/25/docs/api/[Java Platform, Standard Edition (SE) API, version 25]
 
 // JAKARTA EE SPECS //
-// TODO: update for EE 12
-:lkEjbSpec: link:https://jakarta.ee/specifications/enterprise-beans/4.0/[Jakarta Enterprise Beans Specification, version 4.0]
-:lkPlatformSpec: link:https://jakarta.ee/specifications/platform/11/[Jakarta Platform Specification, version 11]
-:lkAuthSpec: link:https://jakarta.ee/specifications/authentication/3.0/[Jakarta Authentication Specification, version 3.0]
-:lkValSpec: link:https://jakarta.ee/specifications/bean-validation/3.1/[Jakarta Validation Specification, version 3.1]
-:lkTransSpec: link:https://jakarta.ee/specifications/transactions/2.0/[Jakarta Transactions Specification, version 2.0]
-:lkAnnoSpec: link:https://jakarta.ee/specifications/annotations/3.0/[Jakarta Annotations Specification, version 3.0]
-:lkServletSpec: link:https://jakarta.ee/specifications/servlet/6.1/[Jakarta Servlet Specification, version 6.1]
-:lkCdiSpec: link:https://jakarta.ee/specifications/cdi/4.1/[Jakarta Contexts and Dependency Injection (CDI) Specification, version 4.1]
+:lkEjbSpec: link:https://jakarta.ee/specifications/enterprise-beans/4.1/[Jakarta Enterprise Beans Specification, version 4.1]
+:lkPlatformSpec: link:https://jakarta.ee/specifications/platform/12/[Jakarta Platform Specification, version 12]
+:lkAuthSpec: link:https://jakarta.ee/specifications/authentication/3.1/[Jakarta Authentication Specification, version 3.1]
+:lkValSpec: link:https://jakarta.ee/specifications/bean-validation/4.0/[Jakarta Validation Specification, version 4.0]
+:lkTransSpec: link:https://jakarta.ee/specifications/transactions/2.1/[Jakarta Transactions Specification, version 2.1]
+:lkAnnoSpec: link:https://jakarta.ee/specifications/annotations/3.1/[Jakarta Annotations Specification, version 3.1]
+:lkServletSpec: link:https://jakarta.ee/specifications/servlet/6.2/[Jakarta Servlet Specification, version 6.2]
+:lkCdiSpec: link:https://jakarta.ee/specifications/cdi/5.0/[Jakarta Contexts and Dependency Injection (CDI) Specification, version 5.0]
 
 // JAKARTA EE API //
 :lkDeployApi: link:https://jakarta.ee/specifications/deployment/[Jakarta Deployment API, version 1.7]]


### PR DESCRIPTION
While reading chapter 8 of the specification to decide where to cover read-only transactions which is being added by #168 , I noticed some grammar errors, references to old levels of specifications, and inconsistency in referring to "Jakarta Transaction" vs "Jakarta Transaction's" vs "Jakarta Transactions".  This PR cleans up all of these issues prior to making the updates for #168